### PR TITLE
Base Ruby 2.1.2 Image

### DIFF
--- a/shopkeep-ruby/2.1.2/Dockerfile
+++ b/shopkeep-ruby/2.1.2/Dockerfile
@@ -1,0 +1,42 @@
+FROM buildpack-deps:trusty
+MAINTAINER John Maguire <jmaguire@shopkeep.com>
+
+ENV RUBY_MAJOR 2.1
+ENV RUBY_VERSION 2.1.2
+ENV RUBY_DOWNLOAD_SHA256 f22a6447811a81f3c808d1c2a5ce3b5f5f0955c68c9a749182feb425589e6635
+ENV RUBYGEMS_VERSION 2.4.8
+
+# skip installing gem documentation
+RUN echo 'install: --no-document\nupdate: --no-document' >> "$HOME/.gemrc"
+
+# some of ruby's build scripts are written in ruby
+# we purge this later to make sure our final image uses what we just built
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y bison libgdbm-dev ruby \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /usr/src/ruby \
+  && curl -fSL -o ruby.tar.gz "http://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR/ruby-$RUBY_VERSION.tar.gz" \
+  && echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.gz" | sha256sum -c - \
+  && tar -xzf ruby.tar.gz -C /usr/src/ruby --strip-components=1 \
+  && rm ruby.tar.gz \
+  && cd /usr/src/ruby \
+  && autoconf \
+  && ./configure --disable-install-doc \
+  && make -j"$(nproc)" \
+  && make install \
+  && apt-get purge -y --auto-remove bison libgdbm-dev ruby \
+  && gem update --system $RUBYGEMS_VERSION \
+  && rm -r /usr/src/ruby
+
+# install things globally, for great justice
+ENV GEM_HOME /usr/local/bundle
+ENV PATH $GEM_HOME/bin:$PATH
+
+ENV BUNDLER_VERSION 1.10.6
+
+RUN gem install bundler --version "$BUNDLER_VERSION" \
+  && bundle config --global path "$GEM_HOME" \
+  && bundle config --global bin "$GEM_HOME/bin"
+
+# don't create ".bundle" in all our apps
+ENV BUNDLE_APP_CONFIG $GEM_HOME

--- a/shopkeep-ruby/2.1.2/Dockerfile
+++ b/shopkeep-ruby/2.1.2/Dockerfile
@@ -6,6 +6,12 @@ ENV RUBY_VERSION 2.1.2
 ENV RUBY_DOWNLOAD_SHA256 f22a6447811a81f3c808d1c2a5ce3b5f5f0955c68c9a749182feb425589e6635
 ENV RUBYGEMS_VERSION 2.4.8
 
+ENV GEM_HOME /usr/local/bundle
+ENV PATH $GEM_HOME/bin:$PATH
+ENV BUNDLE_APP_CONFIG $GEM_HOME
+
+ENV BUNDLER_VERSION 1.10.6
+
 # skip installing gem documentation
 RUN echo 'install: --no-document\nupdate: --no-document' >> "$HOME/.gemrc"
 
@@ -28,15 +34,6 @@ RUN apt-get update \
   && gem update --system $RUBYGEMS_VERSION \
   && rm -r /usr/src/ruby
 
-# install things globally, for great justice
-ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-
-ENV BUNDLER_VERSION 1.10.6
-
 RUN gem install bundler --version "$BUNDLER_VERSION" \
   && bundle config --global path "$GEM_HOME" \
   && bundle config --global bin "$GEM_HOME/bin"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME


### PR DESCRIPTION
Ruby 2.1.2 image based off Ubuntu 14.04 with build deps. When doing your docker build/push this should be tagged with the ruby version, so shopkeep/ruby:2.1.2 allowing for other shopkeep/ruby images.