### PR TITLE
AWS SNS to HipChat

### DIFF
--- a/aws-sns-to-hipchat/Dockerfile
+++ b/aws-sns-to-hipchat/Dockerfile
@@ -1,0 +1,14 @@
+FROM shopkeep-ruby:2.1.2
+MAINTAINER John Maguire <jmaguire@shopkeep.com>
+
+ENV RACK_ENV production
+ENV HIPCHAT_AUTH_TOKEN <REPLACEME>
+
+COPY aws_sns_to_hipchat /
+
+RUN bundle install
+
+EXPOSE 8088
+
+CMD ["ruby", "aws_sns_to_hipchat.rb", "-p 8088"]
+


### PR DESCRIPTION
Our AWS SNS HIPCHAT application rolled into a docker image based off shopkeep-ruby:2.1.2  
Ref this pull https://github.com/shopkeep/dockerfiles/pull/5