### PR TITLE
Added Go 1.5 base image

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get install -y build-essential && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN go get github.com/tools/godep
-RUN go get golang.org/x/tools/cmd/cover
-RUN go get github.com/golang/lint/golint
-RUN go get golang.org/x/tools/cmd/vet
+RUN go get github.com/tools/godep \
+           golang.org/x/tools/cmd/cover \
+           github.com/golang/lint/golint \
+           golang.org/x/tools/cmd/vet

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.5.2
+MAINTAINER ShopKeep Developers <developers@shopkeep.com>
+
+RUN apt-get update && \
+    apt-get install -y build-essential && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN go get github.com/tools/godep
+RUN go get golang.org/x/tools/cmd/cover
+RUN go get github.com/golang/lint/golint
+RUN go get golang.org/x/tools/cmd/vet


### PR DESCRIPTION
This PR is a first attempt at defining a common base image to use across all ShopKeep Go services.

This image includes the most common Go tools (vet, lint, godep, etc) that we use across all of our Go applications and removes the need to handle installation of these on a per-application basis.