### PR TITLE
Update the Riak script location

### DIFF
--- a/riak/Dockerfile
+++ b/riak/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Paul Guelpa <paul@shopkeep.com>
 
 RUN apt-get update && apt-get install -y curl
 
-RUN curl https://packagecloud.io/install/repositories/basho/riak/script.deb | bash
+RUN curl https://packagecloud.io/install/repositories/basho/riak/script.deb.sh | bash
 RUN apt-get install -y riak=2.0.1-1 && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY riak.conf /etc/riak/riak.conf


### PR DESCRIPTION
Why:

* The previous one wasn't available anymore

This change addresses the need by:

* updating to the location used on the offical Riak Docker image