### PR TITLE
Update base Go image to 1.6.0

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.2
+FROM golang:1.6.0
 MAINTAINER ShopKeep Developers <developers@shopkeep.com>
 
 RUN apt-get update && \


### PR DESCRIPTION
This PR updates the base Go image to 1.6.0.