### PR TITLE
Add base pyenv image for build and test purposes

### DIFF
--- a/pyenv/Dockerfile
+++ b/pyenv/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:18.04
+
+# configure default environment
+ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV PATH /root/.pyenv/shims:/root/.pyenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PYENV_ROOT /root/.pyenv
+ENV PYTHONDONTWRITEBYTECODE 1
+
+# install system-level dependencies
+RUN apt-get update && \
+    apt-get install -y git make build-essential libssl-dev zlib1g-dev \
+                       libbz2-dev libreadline-dev libsqlite3-dev wget curl \
+                       llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev
+
+# install and configure pyenv
+RUN curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
+RUN pyenv update
+
+# install all supported Python versions
+RUN pyenv install 2.7.15
+RUN pyenv install 3.5.5
+RUN pyenv install 3.6.5
+RUN pyenv rehash
+RUN pyenv global 3.6.5 3.5.5 2.7.15
+
+# install build and test dependencies
+RUN pip install --upgrade pip tox wheel
+
+WORKDIR /usr/src/app
+CMD [ "python" ]

--- a/pyenv/README.md
+++ b/pyenv/README.md
@@ -1,0 +1,18 @@
+# pyenv
+
+Docker image containing pyenv and multiple versions of Python. Used as a base image for testing and building Python libraries.
+
+## Available versions
+
+The following Python versions are available in this image:
+
+- 2.7.15
+- 3.5.5
+- 3.6.5
+
+## Available libraries
+
+The following libraries are preinstalled globally in this image:
+
+- `tox`: For testing against multiple versions of Python
+- `wheel`: For building binary wheels for distribution


### PR DESCRIPTION
This PR adds a base image with pyenv and multiple versions of Python. This image is intended for use as a build and test environment for Python libraries.