### PR TITLE
[NOTICKET] Add python 3.7 support to shopkeep/pyenv

### DIFF
--- a/pyenv/Dockerfile
+++ b/pyenv/Dockerfile
@@ -22,8 +22,9 @@ RUN pyenv update
 RUN pyenv install 2.7.15
 RUN pyenv install 3.5.5
 RUN pyenv install 3.6.5
+RUN pyenv install 3.7.0
 RUN pyenv rehash
-RUN pyenv global 3.6.5 3.5.5 2.7.15
+RUN pyenv global 3.7.0 3.6.5 3.5.5 2.7.15
 
 # install build and test dependencies
 RUN pip install --upgrade pip tox wheel

--- a/pyenv/README.md
+++ b/pyenv/README.md
@@ -9,6 +9,7 @@ The following Python versions are available in this image:
 - 2.7.15
 - 3.5.5
 - 3.6.5
+- 3.7.0
 
 ## Available libraries
 


### PR DESCRIPTION
This PR adds support of python 3.7.0 to shopkeep/pyenv.